### PR TITLE
feat(text-effects): add indentation after quote if missing

### DIFF
--- a/tests/markup/test_text_effects.py
+++ b/tests/markup/test_text_effects.py
@@ -214,12 +214,14 @@ class TestQuote:
         assert (
             convert(
                 """
+Preceding line
 bq. First quote
 bq. Second quote
 Next line
 """
             )
             == """
+Preceding line
 > First quote
 > Second quote
 

--- a/tests/markup/test_text_effects.py
+++ b/tests/markup/test_text_effects.py
@@ -210,6 +210,23 @@ class TestQuote:
         assert convert("  bq. Some quote") == "  > Some quote"
         assert convert("text  bq. Some quote") == "text  bq. Some quote"
 
+    def test_adjacent_text(self):
+        assert (
+            convert(
+                """
+bq. First quote
+bq. Second quote
+Next line
+"""
+            )
+            == """
+> First quote
+> Second quote
+
+Next line
+"""
+        )
+
 
 class TestBlockQuote:
     def test_basic_conversion(self):


### PR DESCRIPTION
I found that the quote block must contain an empty line after it, otherwise the text after it will be part of the quote.
```
bq. Quote text
Text line
```
must be converted to
```
> Quote text

Text line
```
![image](https://user-images.githubusercontent.com/26367657/224532836-395ca62c-e1f5-4539-88f0-24e2ec2940b3.png)
instead of 
```
> Quote text
Text line
```
![image](https://user-images.githubusercontent.com/26367657/224532824-08d48572-f20b-4622-8838-5b2ab84ece5f.png)
