### PR TITLE
fix: Convert emphasis with + to *

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ convert("[Winston Smith|~accountid:internal-id] woke up with the word 'Shakespea
 |`_emphasis_`|Not converted (the same syntax)|
 |`??citation??`|`<q>citation</q>`|
 |`-deleted-`|`~~deleted~~`|
-|`+inserted+`|`inserted`|
+|`+inserted+`|`*inserted*`|
 |`^superscript^`|`<sup>superscript</sup>`|
 |`~subscript~`|`<sub>subscript</sub>`|
 |`{{monospaced}}`|`` `monospaced` ``|

--- a/jira2markdown/markup/text_effects.py
+++ b/jira2markdown/markup/text_effects.py
@@ -84,8 +84,8 @@ class Strikethrough(QuotedElement):
 
 class Underline(QuotedElement):
     TOKEN = "+"
-    QUOTE_CHAR = "<u>"
-    END_QUOTE_CHAR = "</u>"
+    QUOTE_CHAR = "*"
+    END_QUOTE_CHAR = "*"
 
 
 class InlineQuote(QuotedElement):

--- a/tests/markup/test_mixed_content.py
+++ b/tests/markup/test_mixed_content.py
@@ -50,11 +50,11 @@ class TestRecursiveContent:
     def test_underline_color(self):
         assert (
             convert("+text {color:blue}+text inside+{color} outside+")
-            == '<u>text <font color="blue"><u>text inside</u></font> outside</u>'
+            == '*text <font color="blue">*text inside*</font> outside*'
         )
         assert (
             convert("+text {color:blue}contains+ token{color} outside+")
-            == '<u>text <font color="blue">contains+ token</font> outside</u>'
+            == '*text <font color="blue">contains+ token</font> outside*'
         )
 
     def test_inlinequote_color(self):
@@ -100,7 +100,7 @@ class TestRecursiveContent:
         ("headings", "h2. %s", "## %s"),
         ("bold", "*%s*", "**%s**"),
         ("strikethrough", "-%s-", "~~%s~~"),
-        ("underline", "+%s+", "<u>%s</u>"),
+        ("underline", "+%s+", "*%s*"),
         ("inlinequote", "??%s??", "<q>%s</q>"),
         ("superscript", "^%s^", "<sup>%s</sup>"),
         ("subscript", "~%s~", "<sub>%s</sub>"),
@@ -487,7 +487,7 @@ Some text
 class TestLink:
     def test_alias_markup(self):
         assert (
-            convert("[+box@example.com+|mailto:box@example.com]") == "[<u>box@example.com</u>](mailto:box@example.com)"
+            convert("[+box@example.com+|mailto:box@example.com]") == "[*box@example.com*](mailto:box@example.com)"
         )
         assert convert("[box+tag@example.com|mailto:box+tag@example.com]") == "<box+tag@example.com>"
 

--- a/tests/markup/test_text_effects.py
+++ b/tests/markup/test_text_effects.py
@@ -66,11 +66,11 @@ class TestStrikethrough:
 
 class TestUnderline:
     def test_basic_conversion(self):
-        assert convert("inside +some long+ text") == "inside <u>some long</u> text"
+        assert convert("inside +some long+ text") == "inside *some long* text"
 
     def test_line_endings(self):
-        assert convert("+start string end+") == "<u>start string end</u>"
-        assert convert("\n+start line end+\n") == "\n<u>start line end</u>\n"
+        assert convert("+start string end+") == "*start string end*"
+        assert convert("\n+start line end+\n") == "\n*start line end*\n"
 
     def test_match_start_conditions(self):
         assert convert("no + space after start+") == "no + space after start+"
@@ -79,7 +79,7 @@ class TestUnderline:
     def test_match_end_conditions(self):
         assert convert("+text +") == "+text +"
         assert convert("+word+connector") == "+word+connector"
-        assert convert("+skip +spacing + char+") == "<u>skip +spacing + char</u>"
+        assert convert("+skip +spacing + char+") == "*skip +spacing + char*"
 
     def test_multiline(self):
         assert convert("+multiline\nunderline+") == "+multiline\nunderline+"


### PR DESCRIPTION
Render emphasis from `+foo+` to `*foo*`

Closes #26
