### PR TITLE
Changed table separator from single-hyphen (`-`) to triple-hyphen (`---`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ convert("[Winston Smith|~accountid:internal-id] woke up with the word 'Shakespea
 
 ```
 |heading 1|heading 2|heading 3|
-|-|-|-|
+|---|---|---|
 |col A1|col A2|col A3|
 |col B1|col B2|col B3|
 ```

--- a/jira2markdown/markup/tables.py
+++ b/jira2markdown/markup/tables.py
@@ -46,7 +46,7 @@ class Table(AbstractMarkup):
         output[0] += "|" * (max_columns_count - len(lines[0]))
 
         # Insert header delimiter after the first row
-        output.insert(1, "|" + "-|" * max(max_columns_count, 1))
+        output.insert(1, "|" + "---|" * max(max_columns_count, 1))
 
         return "\n".join(output) + "\n"
 

--- a/tests/markup/test_mixed_content.py
+++ b/tests/markup/test_mixed_content.py
@@ -170,7 +170,7 @@ class TestInlineElements:
     [
         ("blockquote", "{quote}%s{quote}", ["> %s", "> %s"]),
         ("panel", "{panel}%s{panel}", ["> %s", "> %s"]),
-        ("table", "|%s\n|row", ["|%s|\n|-|\n|row|\n"]),
+        ("table", "|%s\n|row", ["|%s|\n|---|\n|row|\n"]),
         ("unordered_list", "* %s", ["- %s", "  %s"]),
         ("ordered_list", "# %s", ["1. %s", "   %s"]),
     ],
@@ -196,7 +196,7 @@ class TestBlockElements:
         if token == "table":
             pytest.skip(f"Skip nested tests for {token} token")
         else:
-            assert convert(test_input % "|Table") == self.render_expected(expected, "|Table|\n|-|\n")
+            assert convert(test_input % "|Table") == self.render_expected(expected, "|Table|\n|---|\n")
 
     def test_list(self, token, test_input, expected):
         if token in ["unordered_list", "ordered_list"]:
@@ -254,21 +254,21 @@ class TestTableContent:
     def test_basic_markup(self):
         assert (
             convert("| Table *bold header* and {color:red}colored title{color} |")
-            == '| Table **bold header** and <font color="red">colored title</font> |\n|-|\n'
+            == '| Table **bold header** and <font color="red">colored title</font> |\n|---|\n'
         )
 
     def test_cell_image(self):
-        assert convert("|!image.png|width=300!") == '|<img src="image.png" width="300" />|\n|-|\n'
+        assert convert("|!image.png|width=300!") == '|<img src="image.png" width="300" />|\n|---|\n'
 
     def test_cell_link(self):
-        assert convert("|[link|http://example.com]|") == "|[link](http://example.com)|\n|-|\n"
+        assert convert("|[link|http://example.com]|") == "|[link](http://example.com)|\n|---|\n"
 
     def test_cell_mailto(self):
-        assert convert("|[mailto:user@example.com]|") == "|<user@example.com>|\n|-|\n"
-        assert convert("|[-alias-|mailto:user@example.com]|") == "|[~~alias~~](mailto:user@example.com)|\n|-|\n"
+        assert convert("|[mailto:user@example.com]|") == "|<user@example.com>|\n|---|\n"
+        assert convert("|[-alias-|mailto:user@example.com]|") == "|[~~alias~~](mailto:user@example.com)|\n|---|\n"
 
     def test_cell_mention(self):
-        assert convert("|[user|~uuid]|", {"uuid": "elliot"}) == "|@elliot|\n|-|\n"
+        assert convert("|[user|~uuid]|", {"uuid": "elliot"}) == "|@elliot|\n|---|\n"
 
 
 class TestPanelContent:

--- a/tests/markup/test_tables.py
+++ b/tests/markup/test_tables.py
@@ -13,7 +13,7 @@ class TestTable:
             )
             == """
 |header 1|header 2|header 3|
-|-|-|-|
+|---|---|---|
 |cell 1-1|cell 1-2|cell 1-3|
 |cell 2-1|cell 2-2|cell 2-3|
 """
@@ -30,7 +30,7 @@ class TestTable:
             )
             == """
 |header 1|header 2|header 3|
-|-|-|-|
+|---|---|---|
 |cell 1-1|cell 1-2|cell 1-3|
 |cell 2-1|cell 2-2|cell 2-3|
 """
@@ -47,7 +47,7 @@ class TestTable:
             )
             == """
 |header 1|header 2||
-|-|-|-|
+|---|---|---|
 |cell 1-1|cell 1-2|cell 1-3|
 |cell 2-1|
 """
@@ -64,14 +64,14 @@ class TestTable:
             )
             == """
 |header 1|header 2|header 3|
-|-|-|-|
+|---|---|---|
 |cell 1-1|cell 1-2|
 |cell 2-1|
 """
         )
 
     def test_smallest_table(self):
-        assert convert("|header") == "|header|\n|-|\n"
+        assert convert("|header") == "|header|\n|---|\n"
 
     def test_multiline_text(self):
         assert (
@@ -90,7 +90,7 @@ row
             )
             == """
 |multi<br>line <br>header||
-|-|-|
+|---|---|
 |multi<br>line <br>row|sibling row|
 |open <br>end <br>row|
 """
@@ -110,7 +110,7 @@ text after table
 text before table
 
 |header 1|header 2|
-|-|-|
+|---|---|
 |cell 1-1|cell 1-2|
 
 text after table
@@ -130,12 +130,12 @@ text after table
             )
             == """
 |text|
-|-|
+|---|
 |end|
 """
         )
 
     def test_empty_start_lines(self):
-        assert convert("  \n|header") == "  \n|header|\n|-|\n"
-        assert convert("  \n \t \n|header") == "  \n \t \n|header|\n|-|\n"
-        assert convert("  \n text \n|header") == "  \n text \n\n|header|\n|-|\n"
+        assert convert("  \n|header") == "  \n|header|\n|---|\n"
+        assert convert("  \n \t \n|header") == "  \n \t \n|header|\n|---|\n"
+        assert convert("  \n text \n|header") == "  \n text \n\n|header|\n|---|\n"


### PR DESCRIPTION
Changed table separator from single-hyphen (`-`) to triple-hyphen (`---`) and updated test. This change brings the resulting tables into compliance with the YouTrack Markdown implementation.

Fixes #29 